### PR TITLE
VIDEO-33: PLF - Page does not load because of weemo

### DIFF
--- a/weemo-extension-webapp/src/main/java/org/exoplatform/portlet/videocall/ResponseFilter.java
+++ b/weemo-extension-webapp/src/main/java/org/exoplatform/portlet/videocall/ResponseFilter.java
@@ -16,6 +16,8 @@ import javax.portlet.filter.RenderFilter;
 
 import org.w3c.dom.Element;
 
+import org.exoplatform.services.log.ExoLogger;
+import org.exoplatform.services.log.Log;
 import org.exoplatform.services.videocall.VideoCallService;
 
 
@@ -24,7 +26,7 @@ public class ResponseFilter implements RenderFilter
 {
   
   public static final String INVALID_WEEMO_JS_MESSAGE = "/* Not allowed (disabled) */";
-  
+  private static final Log LOG = ExoLogger.getLogger(ResponseFilter.class.getName());
   public void init(FilterConfig filterConfig) throws PortletException
   {
   }
@@ -62,7 +64,7 @@ public class ResponseFilter implements RenderFilter
       br.close();
       return ! (stringBuilder.toString().toUpperCase().equals(INVALID_WEEMO_JS_MESSAGE.toUpperCase()));
     } catch (Exception e) {
-      e.printStackTrace();
+      LOG.error("Can not get " + "https://download.rtccloud.net/js/webappid/" + weemoKey,e);
     }
     return false;
   }

--- a/weemo-extension-webapp/src/main/java/org/exoplatform/portlet/videocall/ResponseFilter.java
+++ b/weemo-extension-webapp/src/main/java/org/exoplatform/portlet/videocall/ResponseFilter.java
@@ -1,7 +1,10 @@
 package org.exoplatform.portlet.videocall;
 
-import org.exoplatform.services.videocall.VideoCallService;
-import org.w3c.dom.Element;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.URL;
+import java.net.URLConnection;
 
 import javax.portlet.MimeResponse;
 import javax.portlet.PortletException;
@@ -10,11 +13,18 @@ import javax.portlet.RenderResponse;
 import javax.portlet.filter.FilterChain;
 import javax.portlet.filter.FilterConfig;
 import javax.portlet.filter.RenderFilter;
-import java.io.IOException;
+
+import org.w3c.dom.Element;
+
+import org.exoplatform.services.videocall.VideoCallService;
+
+
 
 public class ResponseFilter implements RenderFilter
 {
-
+  
+  public static final String INVALID_WEEMO_JS_MESSAGE = "/* Not allowed (disabled) */";
+  
   public void init(FilterConfig filterConfig) throws PortletException
   {
   }
@@ -26,10 +36,35 @@ public class ResponseFilter implements RenderFilter
     if (weemoKey!=null && !"".equals(weemoKey)) {
       Element jQuery1 = response.createElement("script");
       jQuery1.setAttribute("type", "text/javascript");
-      jQuery1.setAttribute("src", "https://download.rtccloud.net/js/webappid/"+weemoKey+" ");
+      if(checkWeemoJavaScript()){
+        jQuery1.setAttribute("src", "https://download.rtccloud.net/js/webappid/"+weemoKey+" ");
+      }else{
+        jQuery1.setTextContent("console.log('Can not load https://download.rtccloud.net/js/webappid/" + weemoKey + "');");
+      }
       response.addProperty(MimeResponse.MARKUP_HEAD_ELEMENT, jQuery1);
     }
     chain.doFilter(request, response);
+  }
+  
+  private boolean checkWeemoJavaScript(){
+    VideoCallService videoCallService = new VideoCallService();  
+    String weemoKey = videoCallService.getWeemoKey();
+    URL url;
+    try {
+      url = new URL("https://download.rtccloud.net/js/webappid/" + weemoKey);
+      URLConnection conn = url.openConnection();
+      BufferedReader br = new BufferedReader(new InputStreamReader(conn.getInputStream()));
+      StringBuilder stringBuilder = new StringBuilder();
+      String inputLine;
+      while ((inputLine = br.readLine()) != null) {
+        stringBuilder.append(inputLine);
+      }
+      br.close();
+      return ! (stringBuilder.toString().toUpperCase().equals(INVALID_WEEMO_JS_MESSAGE.toUpperCase()));
+    } catch (Exception e) {
+      e.printStackTrace();
+    }
+    return false;
   }
 
   public void destroy()


### PR DESCRIPTION
I tried to load https://download.rtccloud.net/js/webappid/$weemoKey as asynchronous JS but I face a problem.
There are some JS files for Weemo-extension and they depend on https://download.rtccloud.net/js/webappid/$weemoKey.
So to let Weemo-extension work property, https://download.rtccloud.net/js/webappid/$weemoKey must be loaded before other ones.

To control https://download.rtccloud.net/js/webappid/$weemoKey, I suggest a solution:
in ResponseFilter.java , if it is available ( the weemokey is valid) we will add it to HTML page. If it is unavailable, don't add it in HTML page.
