### PR TITLE
VIDEO-38: Missing "Video Calls" in the Administration menu when installi...

### DIFF
--- a/weemo-extension-webapp/src/main/webapp/WEB-INF/conf/weemo-extension/portal/portal-configuration.xml
+++ b/weemo-extension-webapp/src/main/webapp/WEB-INF/conf/weemo-extension/portal/portal-configuration.xml
@@ -12,7 +12,11 @@
       <set-method>initListener</set-method>
       <type>org.exoplatform.portal.config.NewPortalConfigListener</type>
       <description>this listener init the portal configuration</description>
-      <init-params>        
+      <init-params>
+        <value-param>
+          <name>override</name>
+          <value>true</value>
+        </value-param>
         <object-param>
           <name>group.configuration</name>
           <description>description</description>


### PR DESCRIPTION
...ng the add-on after the first startup

Fix description:
- Restore "override=true" for NewPortalConfig.
